### PR TITLE
Quota c3

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -2,6 +2,9 @@ require 'sinatra'
 require 'sinatra/reloader' if development?
 require 'open3'
 
+# omitting at this time: files_quota, files_grace, blocks_quota, blocks_grace
+Volume = Struct.new(:name, :blocks_count, :blocks_limit, :files_count, :files_limit)
+
 get '/' do
   # Define your variables
   @title = "Quota"
@@ -19,6 +22,12 @@ get '/' do
 
   @output = "As of 2017-08-13T16:02:39.194266 userid efranz on /users/PZS0530 used 32.57MB of quota 500GB and 2 files of quota 1000000 files\n" \
   "As of 2017-08-13T16:02:39.483896 userid efranz on /users/PZS0562 used 97.08GB of quota 500GB and 916417 files of quota 1000000 files\n"
+
+  # example of what the model data could look like
+  @volumes = []
+  @volumes << Volume.new("/users/PZS0562", 101800800, 524288000, 916417, 1000000)
+  @volumes << Volume.new("/users/PZS0530", 33352, 524288000, 2, 1000000)
+
 
   # Variables will be available in views/index.erb
   erb :index

--- a/views/chart.erb
+++ b/views/chart.erb
@@ -1,0 +1,61 @@
+<script>
+// use c3.js to generate a bar chart that changes color when passing limit
+var chart = function(selector, title, limit, value) {
+  var warn = Math.round(limit * 0.8);
+  return c3.generate({
+    bindto: selector,
+    padding: {
+      left: 60,
+      right: 60
+    },
+    data: {
+      x: 'x',
+      columns: [
+        ['x', title],
+        ['num ' + title.toLowerCase(), value]
+      ],
+      type: 'bar',
+      color: function(color, d) {
+        if (d.value > warn && d.value < limit)
+          return "#f0ad4e";
+        else if (d.value >= limit)
+          return "#d9534f";
+        else
+          return "#337ab7";
+      }
+
+    },
+    bar: {
+      zerobased: true
+    },
+    axis: {
+      rotated: true,
+      x: {
+        type: 'category',
+      },
+      y: {
+        max: limit,
+        tick: {
+          count: 4,
+          format: function(x) {
+            return Math.round(x);
+          }
+        }
+      }
+    },
+    grid: {
+      y: {
+        lines: [{
+          value: warn,
+          text: "warn",
+          position: 'start'
+        }, {
+          value: limit,
+          text: "limit",
+          position: 'start'
+        }]
+      },
+    }
+  });
+};
+</script>

--- a/views/index.erb
+++ b/views/index.erb
@@ -3,14 +3,14 @@
 
 <div class="report">
   <h3>/users/PZS0562</h3>
-  <div class="chart chart1" data-title = "916417 files", data-ranges = "[0,800000,1000000]", data-measures="[916417]" data-markers="[]"><svg></svg></div>
-  <div class="chart chart2" data-title = "101800800 blocks", data-ranges = "[0,419430400,524288000]", data-measures="[101800800]" data-markers="[]"><svg></svg></div>
+  <div class="chart chart1" data-title = "Blocks", data-limit = "524288000", data-value="101800800"></div>
+  <div class="chart chart2" data-title = "Files", data-limit = "1000000", data-value="916417"></div>
 </div>
 
 <div class="report">
   <h3>/users/PZS0530</h3>
-  <div class="chart chart3" data-title = "2 files", data-ranges = "[0,800000,1000000]", data-measures="[2]" data-markers="[]"><svg></svg></div>
-  <div class="chart chart4" data-title = "33352 blocks", data-ranges = "[0,419430400,524288000]", data-measures="[33352]" data-markers="[]"><svg></svg></div>
+  <div class="chart chart3" data-title = "Blocks", data-limit = "524288000", data-value="33352"></div>
+  <div class="chart chart4" data-title = "Files", data-ranges = "1000000", data-value="2"></div>
 </div>
 
 Output generated: <%= Time.now %>
@@ -28,27 +28,13 @@ Disk quotas for user efranz (uid 10851):
                 101800800  524288000 524288000          916451  1000000 1000000
 </pre>
 
+<%= erb(:chart) %>
 <script>
-var chart = function(selector, data){
-  nv.addGraph(function() {
-      var chart = nv.models.bulletChart();
 
-      d3.select(selector)
-      .datum(data)
-      .transition().duration(1000)
-      .call(chart);
+$(".chart").each(function(){
+  var d = $(this).data();
+  chart(this, d.title, d.limit, d.value);
+});
 
-      return chart;
-  });
-};
-
-chart($('.chart1').find('svg').get(0), $('.chart1').data());
-chart($('.chart2').find('svg').get(0), $('.chart2').data());
-chart($('.chart3').find('svg').get(0), $('.chart3').data());
-chart($('.chart4').find('svg').get(0), $('.chart4').data());
-
-// FIXME:
-//$('.chart').each(function(){
-//    chart($(this).find('svg').get(0), $(this).data());
-//});
+//chart($('.chart1').get(0), "Blocks", 524288000, 101800800);
 </script>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -8,13 +8,15 @@
   <%= erb(:ood_styles) %>
 
   <link rel="stylesheet" type="text/css" href="<%= url("/nvd3-1.8.1/nv.d3.css") %>">
+  <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.15/c3.min.css">
 
   <script src="<%= url("/jquery-3.2.1/jquery-3.2.1.min.js") %>"></script>
   <script src="<%= url("/bootstrap-3.3.7-dist/js/bootstrap.min.js") %>"></script>
   <script src="<%= url("/d3-3.5.17/d3.min.js") %>"></script>
   <script src="<%= url("/nvd3-1.8.1/nv.d3.min.js") %>"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.15/c3.min.js"></script>
   <style>
-  .report div.chart { height: 50px;  }
+  .report div.chart { height: 100px;  }
   </style>
 </head>
 <body>


### PR DESCRIPTION
Another charting experiment with quota.

Would be better if the graphs were in a table, where volume name was a column, the actual values were columns, and then the graphs were in one column.

The virtue of this experiment is that:

1. c3 is built on top of d3 and is used by patternfly (redhat project built on bootstrap)
2. c3 is javascript configuration vs using d3 itself, so it might be an easier thing to understand for some people
3. shows that a simple bar chart in the quota example can be just as effective as a bullet chart

Also, as long as the scales were the same, a bar chart without the warn and limit lines displayed would still be useful as long as it were in a table that indicated in text.

Negatives:

1. its a lot more code than the nvd3 example
2. the way horizontal bar charts works is it is a "rotated" vertical bar chart, so configuration still works assuming it is a bar chart
3. c3 seems to have a lot of "gotchas", things don't work the way you expect them to
