### PR TITLE
Refactor, add test, and fix code reloading

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+end
+
+task :default => :test

--- a/app.rb
+++ b/app.rb
@@ -5,6 +5,10 @@ require 'open3'
 AppProcess = Struct.new(:user, :pid, :pct_cpu, :pct_mem, :vsz, :rss, :tty, :stat, :start, :time, :command)
 
 helpers do
+  def title
+    "Currently Running OnDemand Passenger Apps"
+  end
+
   # Parse a string output from the `ps aux` command and return an array of
   # AppProcess objects, one per process
   def parse_ps(ps_string)
@@ -15,7 +19,6 @@ end
 # Define a route at the root '/' of the app.
 get '/' do
   # Define variables that will be available in the view
-  @title = "Currently Running OnDemand Passenger Apps"
   @command = "ps aux | grep App | grep -v grep"
   @app_processes = []
 

--- a/app.rb
+++ b/app.rb
@@ -1,12 +1,12 @@
 require 'open3'
 
 # There are 11 data values for each `ps` item. Here, we create a Struct object to map
-#  each value to a named parameter.
+#  each value to an attribute on the Struct
 AppProcess = Struct.new(:user, :pid, :pct_cpu, :pct_mem, :vsz, :rss, :tty, :stat, :start, :time, :command)
 
 helpers do
-  # This command will parse a string output from the `ps` command and map it to
-  #  an array of AppProcess objects.
+  # Parse a string output from the `ps aux` command and return an array of
+  # AppProcess objects, one per process
   def parse_ps(ps_string)
     ps_string.split("\n").map { |line| AppProcess.new(*(line.split(" ", 11))) }
   end
@@ -14,12 +14,12 @@ end
 
 # Define a route at the root '/' of the app.
 get '/' do
-  # Define your variables that will be sent to the view.
+  # Define variables that will be available in the view
   @title = "Currently Running OnDemand Passenger Apps"
   @command = "ps aux | grep App | grep -v grep"
   @app_processes = []
 
-  # Run the command and capture the stdout, stderr, and exit code as separate variables.
+  # Run the command, and parse the output
   stdout_str, stderr_str, status = Open3.capture3(@command)
   if status.success?
     @app_processes = parse_ps(stdout_str)

--- a/app.rb
+++ b/app.rb
@@ -17,16 +17,16 @@ get '/' do
   # Define your variables that will be sent to the view.
   @title = "Currently Running OnDemand Passenger Apps"
   @command = "ps aux | grep App | grep -v grep"
+  @app_processes = []
 
   # Run the command and capture the stdout, stderr, and exit code as separate variables.
   stdout_str, stderr_str, status = Open3.capture3(@command)
+  if status.success?
+    @app_processes = parse_ps(stdout_str)
+  else
+    @error = "Command '#{@command}' exited with error: #{stderr_str}"
+  end
 
-  # Parse the stdout of the command and set the resulting object array to a variable.
-  @app_processes = parse_ps(stdout_str)
-
-  # If there was an error performing the command, set it to an error variable.
-  @error = stderr_str unless status.success?
-
-  # Variables will be available in views/index.erb
+  # Render the view
   erb :index
 end

--- a/app.rb
+++ b/app.rb
@@ -1,34 +1,22 @@
 require 'open3'
+require './command'
 
-# There are 11 data values for each `ps` item. Here, we create a Struct object to map
-#  each value to an attribute on the Struct
-AppProcess = Struct.new(:user, :pid, :pct_cpu, :pct_mem, :vsz, :rss, :tty, :stat, :start, :time, :command)
+if development?
+  require 'sinatra/reloader'
+  also_reload './command.rb'
+end
 
 helpers do
   def title
     "Currently Running OnDemand Passenger Apps"
   end
-
-  # Parse a string output from the `ps aux` command and return an array of
-  # AppProcess objects, one per process
-  def parse_ps(ps_string)
-    ps_string.split("\n").map { |line| AppProcess.new(*(line.split(" ", 11))) }
-  end
 end
 
 # Define a route at the root '/' of the app.
 get '/' do
-  # Define variables that will be available in the view
-  @command = "ps aux | grep App | grep -v grep"
-  @app_processes = []
-
-  # Run the command, and parse the output
-  stdout_str, stderr_str, status = Open3.capture3(@command)
-  if status.success?
-    @app_processes = parse_ps(stdout_str)
-  else
-    @error = "Command '#{@command}' exited with error: #{stderr_str}"
-  end
+  @command = Command.new
+  @command.exec
+  @error = @command.error
 
   # Render the view
   erb :index

--- a/app.rb
+++ b/app.rb
@@ -1,5 +1,7 @@
-require 'open3'
+require 'erubi'
 require './command'
+
+set :erb, :escape_html => true
 
 if development?
   require 'sinatra/reloader'

--- a/app.rb
+++ b/app.rb
@@ -1,0 +1,32 @@
+require 'open3'
+
+# There are 11 data values for each `ps` item. Here, we create a Struct object to map
+#  each value to a named parameter.
+AppProcess = Struct.new(:user, :pid, :pct_cpu, :pct_mem, :vsz, :rss, :tty, :stat, :start, :time, :command)
+
+helpers do
+  # This command will parse a string output from the `ps` command and map it to
+  #  an array of AppProcess objects.
+  def parse_ps(ps_string)
+    ps_string.split("\n").map { |line| AppProcess.new(*(line.split(" ", 11))) }
+  end
+end
+
+# Define a route at the root '/' of the app.
+get '/' do
+  # Define your variables that will be sent to the view.
+  @title = "Currently Running OnDemand Passenger Apps"
+  @command = "ps aux | grep App | grep -v grep"
+
+  # Run the command and capture the stdout, stderr, and exit code as separate variables.
+  stdout_str, stderr_str, status = Open3.capture3(@command)
+
+  # Parse the stdout of the command and set the resulting object array to a variable.
+  @app_processes = parse_ps(stdout_str)
+
+  # If there was an error performing the command, set it to an error variable.
+  @error = stderr_str unless status.success?
+
+  # Variables will be available in views/index.erb
+  erb :index
+end

--- a/app.rb
+++ b/app.rb
@@ -17,8 +17,7 @@ end
 # Define a route at the root '/' of the app.
 get '/' do
   @command = Command.new
-  @command.exec
-  @error = @command.error
+  @processes, @error = @command.exec
 
   # Render the view
   erb :index

--- a/command.rb
+++ b/command.rb
@@ -1,11 +1,8 @@
 require 'open3'
 
 class Command
-  attr_accessor :command, :processes, :error
-
-  def initialize
-    @command = "ps aux | grep '[A]pp'"
-    @processes = []
+  def to_s
+    "ps aux | grep '[A]pp'"
   end
 
   AppProcess = Struct.new(:user, :pid, :pct_cpu, :pct_mem, :vsz, :rss, :tty, :stat, :start, :time, :command)
@@ -19,16 +16,20 @@ class Command
     end
   end
 
-  def to_str
-    command
-  end
-
+  # Execute the command, and parse the output, returning and array of
+  # AppProcesses and nil for the error string.
+  #
+  # returns [Array<Array<AppProcess>, String] i.e.[processes, error]
   def exec
-    stdout_str, stderr_str, status = Open3.capture3(command)
+    processes, error = [], nil
+
+    stdout_str, stderr_str, status = Open3.capture3(to_s)
     if status.success?
-      self.processes = parse(stdout_str)
+      processes = parse(stdout_str)
     else
-      self.error = "Command '#{command}' exited with error: #{stderr_str}"
+      error = "Command '#{to_s}' exited with error: #{stderr_str}"
     end
+
+    [processes, error]
   end
 end

--- a/command.rb
+++ b/command.rb
@@ -4,7 +4,7 @@ class Command
   attr_accessor :command, :processes, :error
 
   def initialize
-    @command = "ps aux | grep App | grep -v grep"
+    @command = "ps aux | grep '[A]pp'"
     @processes = []
   end
 

--- a/command.rb
+++ b/command.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 class Command
   attr_accessor :command, :processes, :error
 

--- a/command.rb
+++ b/command.rb
@@ -19,7 +19,7 @@ class Command
     end
   end
 
-  def to_s
+  def to_str
     command
   end
 

--- a/command.rb
+++ b/command.rb
@@ -1,0 +1,32 @@
+class Command
+  attr_accessor :command, :processes, :error
+
+  def initialize
+    @command = "ps aux | grep App | grep -v grep"
+    @processes = []
+  end
+
+  AppProcess = Struct.new(:user, :pid, :pct_cpu, :pct_mem, :vsz, :rss, :tty, :stat, :start, :time, :command)
+
+  # Parse a string output from the `ps aux` command and return an array of
+  # AppProcess objects, one per process
+  def parse_ps(ps_string)
+    lines = ps_string.strip.split("\n")
+    lines.map do |line|
+      AppProcess.new(*(line.split(" ", 11)))
+    end
+  end
+
+  def to_s
+    command
+  end
+
+  def exec
+    stdout_str, stderr_str, status = Open3.capture3(command)
+    if status.success?
+      self.processes = parse_ps(stdout_str)
+    else
+      self.error = "Command '#{command}' exited with error: #{stderr_str}"
+    end
+  end
+end

--- a/command.rb
+++ b/command.rb
@@ -10,8 +10,8 @@ class Command
 
   # Parse a string output from the `ps aux` command and return an array of
   # AppProcess objects, one per process
-  def parse_ps(ps_string)
-    lines = ps_string.strip.split("\n")
+  def parse(output)
+    lines = output.strip.split("\n")
     lines.map do |line|
       AppProcess.new(*(line.split(" ", 11)))
     end
@@ -24,7 +24,7 @@ class Command
   def exec
     stdout_str, stderr_str, status = Open3.capture3(command)
     if status.success?
-      self.processes = parse_ps(stdout_str)
+      self.processes = parse(stdout_str)
     else
       self.error = "Command '#{command}' exited with error: #{stderr_str}"
     end

--- a/config.ru
+++ b/config.ru
@@ -1,7 +1,4 @@
 require 'sinatra'
-require 'erubi'
-
-set :erb, :escape_html => true
 
 require './app'
 

--- a/config.ru
+++ b/config.ru
@@ -1,40 +1,9 @@
 require 'sinatra'
 require 'sinatra/reloader' if development?
-require 'open3'
 require 'erubi'
 
 set :erb, :escape_html => true
 
-# There are 11 data values for each `ps` item. Here, we create a Struct object to map
-#  each value to a named parameter.
-AppProcess = Struct.new(:user, :pid, :pct_cpu, :pct_mem, :vsz, :rss, :tty, :stat, :start, :time, :command)
-
-helpers do
-
-  # This command will parse a string output from the `ps` command and map it to
-  #  an array of AppProcess objects.
-  def parse_ps(ps_string)
-    ps_string.split("\n").map { |line| AppProcess.new(*(line.split(" ", 11))) }
-  end
-end
-
-# Define a route at the root '/' of the app.
-get '/' do
-  # Define your variables that will be sent to the view.
-  @title = "Currently Running OnDemand Passenger Apps"
-  @command = "ps aux | grep App | grep -v grep"
-
-  # Run the command and capture the stdout, stderr, and exit code as separate variables.
-  stdout_str, stderr_str, status = Open3.capture3(@command)
-
-  # Parse the stdout of the command and set the resulting object array to a variable.
-  @app_processes = parse_ps(stdout_str)
-
-  # If there was an error performing the command, set it to an error variable.
-  @error = stderr_str unless status.success?
-
-  # Variables will be available in views/index.erb
-  erb :index
-end
+require './app'
 
 run Sinatra::Application

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,4 @@
 require 'sinatra'
-require 'sinatra/reloader' if development?
 require 'erubi'
 
 set :erb, :escape_html => true

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -1,0 +1,4 @@
+$LOAD_PATH.unshift File.expand_path(File.dirname(File.dirname(__FILE__)))
+
+ENV['RACK_ENV'] = 'test'
+require 'minitest/autorun'

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -9,7 +9,7 @@ class TestCommand < Minitest::Test
 efranz    30328  0.1  0.1 462148 28128 ?        Sl   20:28   0:00 Passenger RackApp: /users/PZS0562/efranz/awesim/dev/ood-example-ps
 
 EOF
-    processes = Command.new.parse_ps(output)
+    processes = Command.new.parse(output)
 
     assert_equal 1, processes.count
 

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -1,0 +1,24 @@
+require 'minitest_helper'
+require 'command'
+
+class TestCommand < Minitest::Test
+
+  def test_ps_simple_parsing
+    output = <<-EOF
+
+efranz    30328  0.1  0.1 462148 28128 ?        Sl   20:28   0:00 Passenger RackApp: /users/PZS0562/efranz/awesim/dev/ood-example-ps
+
+EOF
+    processes = Command.new.parse_ps(output)
+
+    assert_equal 1, processes.count
+
+    p = processes.first
+
+    assert_equal "efranz", p.user
+    assert_equal "462148", p.vsz
+    assert_equal "28128", p.rss
+    assert_equal "0:00", p.time
+    assert_equal "Passenger RackApp: /users/PZS0562/efranz/awesim/dev/ood-example-ps", p.command
+  end
+end

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -3,7 +3,7 @@ require 'command'
 
 class TestCommand < Minitest::Test
 
-  def test_ps_simple_parsing
+  def test_command_output_parsing
     output = <<-EOF
 
 efranz    30328  0.1  0.1 462148 28128 ?        Sl   20:28   0:00 Passenger RackApp: /users/PZS0562/efranz/awesim/dev/ood-example-ps

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,4 +1,4 @@
-<h1><%= @title %></h1>
+<h1><%= title %></h1>
 
 Output generated: <%= Time.now %>
 

--- a/views/index.erb
+++ b/views/index.erb
@@ -3,7 +3,7 @@
 Output generated: <%= Time.now %>
 
 <pre>
-$ <%= @command %>
+$ <%= @command.to_s %>
 </pre>
 
 <table class="table table-bordered">
@@ -20,7 +20,7 @@ $ <%= @command %>
     <th>TIME</th>
     <th>COMMAND</th>
   </tr>
-  <% @app_processes.each do |app| %>
+  <% @command.processes.each do |app| %>
   <tr>
     <td><%= app.user %></td>
     <td><%= app.pid %></td>

--- a/views/index.erb
+++ b/views/index.erb
@@ -20,7 +20,7 @@ $ <%= @command %>
     <th>TIME</th>
     <th>COMMAND</th>
   </tr>
-  <% @command.processes.each do |app| %>
+  <% @processes.each do |app| %>
   <tr>
     <td><%= app.user %></td>
     <td><%= app.pid %></td>

--- a/views/index.erb
+++ b/views/index.erb
@@ -3,7 +3,7 @@
 Output generated: <%= Time.now %>
 
 <pre>
-$ <%= @command.to_s %>
+$ <%= @command %>
 </pre>
 
 <table class="table table-bordered">

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -26,7 +26,7 @@
         </button>
         <ul class="navbar-breadcrumbs">
           <li><a href="/pun/sys/dashboard/">OSC OnDemand</a></li>
-          <li><a href="#"><%= title %></a></li>
+          <li><a href="<%= url('/') %>"><%= title %></a></li>
         </ul>
       </div>
 

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title><%= @title %></title>
+  <title><%= title %></title>
   <meta charset="UTF-8">
 
   <%# reload every 15 seconds %>
@@ -26,7 +26,7 @@
         </button>
         <ul class="navbar-breadcrumbs">
           <li><a href="/pun/sys/dashboard/">OSC OnDemand</a></li>
-          <li><a href="#"><%= @title %></a></li>
+          <li><a href="#"><%= title %></a></li>
         </ul>
       </div>
 


### PR DESCRIPTION
We had one config.ru. It didn't support code reloading, and the domain logic was mixed in with the Sinatra plumbing, making it difficult to talk about the domain logic without explaining the Sinatra plumbing in a tutorial. Also, the config.ru wouldn't allow adding any test.

This change separates config.ru into 3 files:

1. config.ru
   ```ruby
   require 'sinatra'
   require './app'
   run Sinatra::Application
   ```

2. app.rb which has the Sinatra app

   ```ruby
   get '/' do
     @command = Command.new
     @command.exec
     @error = @command.error
   
     # Render the view
     erb :index
   end
   ```

3. The `Command` class which has `Command#exec` to execute the command and `Command#parse` to parse the output.

Benefits:

1. auto code reloading for most of the changes you would make
2. test support built in
3. might be easier to write a tutorial around

Drawbacks:

1. more files => we are much further away from the ultra simple config.ru example where we had:

   ```ruby
   require 'sinatra'
   
   get '/' do
     "<pre>#{`ps aux | grep '[A]pp'`}</pre>"
   end
   
   run Sinatra::Application
   ```

   Or even:

   ```ruby
   require 'sinatra'
   
   get '/' do
     @output = "ps aux | grep '[A]pp'"
     erb :index
   end
   
   run Sinatra::Application
   ```
